### PR TITLE
Updated API for new Shopify oauth specifcations

### DIFF
--- a/conf.php
+++ b/conf.php
@@ -2,3 +2,4 @@
 
 	define('SHOPIFY_APP_API_KEY', '');
 	define('SHOPIFY_APP_SHARED_SECRET', '');
+	define('REDIRECT_URI', '');

--- a/oauth.php
+++ b/oauth.php
@@ -14,7 +14,7 @@
 	# Step 2: http://docs.shopify.com/api/authentication/oauth#asking-for-permission
 	if (!isset($_GET['code']))
 	{
-		$permission_url = shopify\authorization_url($_GET['shop'], SHOPIFY_APP_API_KEY, array('read_content', 'write_content', 'read_themes', 'write_themes', 'read_products', 'write_products', 'read_customers', 'write_customers', 'read_orders', 'write_orders', 'read_script_tags', 'write_script_tags', 'read_fulfillments', 'write_fulfillments', 'read_shipping', 'write_shipping'));
+		$permission_url = shopify\authorization_url($_GET['shop'], SHOPIFY_APP_API_KEY, array('read_content', 'write_content', 'read_themes', 'write_themes', 'read_products', 'write_products', 'read_customers', 'write_customers', 'read_orders', 'write_orders', 'read_script_tags', 'write_script_tags', 'read_fulfillments', 'write_fulfillments', 'read_shipping', 'write_shipping'), REDIRECT_URI);
 		die("<script> top.location.href='$permission_url'</script>");
 	}
 


### PR DESCRIPTION
I've amended the API to use REDIRECT_URI as a variable passed through to oauth.php, as the specifications for the Shopify oauth API have changed.

"{redirect_uri} - (Required) substitute this with the URL where you want to redirect the users after they authorize the client. The complete URL specified here must be identical to one of the Application Redirect URLs. Note: in older applications, this parameter was optional, and redirected to the Application Callback URL when no other value was specified." - https://docs.shopify.com/api/authentication/oauth#asking-for-permission
